### PR TITLE
Fix deprecated commandProxy invocation

### DIFF
--- a/src/windows8/PushPluginProxy.js
+++ b/src/windows8/PushPluginProxy.js
@@ -15,4 +15,4 @@ module.exports = {
         }
     }
 };
-require("cordova/windows8/commandProxy").add("PushPlugin", module.exports);
+require("cordova/exec/proxy").add("PushPlugin", module.exports);


### PR DESCRIPTION
`commandProxy` seems to have been deprecated, though it's been poorly communicated [[1](https://github.com/wildabeast/BarcodeScanner/pull/298/files), [2](https://stackoverflow.com/posts/30239743/revisions)].

Was just the victim of this in an app I'm working on, and thought I'd share the fix back :smile: 

[1] https://github.com/wildabeast/BarcodeScanner/pull/298/files
[2] https://stackoverflow.com/posts/30239743/revisions
